### PR TITLE
libthrift isn't actually needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,5 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.5.8</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libthrift</artifactId>
-            <version>0.2.0</version>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Since the plugin just calls the thrift executable, it doesn't need to declare a dependency on libthrift in the pom. Doing so actually prevents this plugin from being used with (for example) libthrift 0.5.0, the latest release.
