### PR TITLE
Updated thrift compatibility and added correct java:beans handling

### DIFF
--- a/src/main/java/org/apache/thrift/maven/Thrift.java
+++ b/src/main/java/org/apache/thrift/maven/Thrift.java
@@ -2,11 +2,15 @@ package org.apache.thrift.maven;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+
+import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
 
 import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
@@ -65,7 +69,7 @@ final class Thrift {
      * @return The exit status of {@code thrift}.
      * @throws CommandLineException
      */
-    public int compile() throws CommandLineException {
+    public int compile() throws CommandLineException, IOException {
 
         for (File thriftFile : thriftFiles) {
             Commandline cl = new Commandline();
@@ -76,8 +80,19 @@ final class Thrift {
             if (result != 0) {
                 return result;
             }
+            File[] list = javaOutputDirectory.listFiles(new FilenameFilter() {
+                @Override
+                public boolean accept(File dir, String name) {
+                    return name.startsWith("gen-");
+               }
+            });
+            for (File file : list) {
+                if(file.exists()){
+                    FileUtils.copyDirectoryStructure(file, javaOutputDirectory);
+                    FileUtils.deleteDirectory(file);
+                }
+            }
         }
-
         // result will always be 0 here.
         return 0;
     }
@@ -97,7 +112,7 @@ final class Thrift {
             command.add("-I");
             command.add(thriftPathElement.toString());
         }
-        command.add("-out");
+        command.add("-o");
         command.add(javaOutputDirectory.toString());
         command.add("--gen");
         command.add(generator);

--- a/src/test/java/org/apache/thrift/maven/TestThrift.java
+++ b/src/test/java/org/apache/thrift/maven/TestThrift.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -53,7 +54,13 @@ public class TestThrift {
         executeThriftCompile();
     }
 
-    private void executeThriftCompile() throws CommandLineException {
+    @Test
+    public void testThriftCompileWithGeneratorOptionBeans() throws Exception {
+        builder.setGenerator("java:beans");
+        executeThriftCompile();
+    }
+    
+    private void executeThriftCompile() throws CommandLineException, IOException {
         final File thriftFile = new File(idlDir, "shared.thrift");
 
         builder.addThriftFile(thriftFile);


### PR DESCRIPTION
Adapt changes to be compatible with Thrift 0.6.1 and backwards.
Move the generated source code files after generation and remove the gen-java dir
Correct the java:beans handling

Change-Id: I1311d36577119a7f7ff23a16682f2035f95f69ae
