### PR TITLE
Use versioned thrift executables

### DIFF
--- a/src/main/java/org/apache/thrift/maven/AbstractThriftMojo.java
+++ b/src/main/java/org/apache/thrift/maven/AbstractThriftMojo.java
@@ -3,6 +3,7 @@ package org.apache.thrift.maven;
 import com.google.common.collect.ImmutableSet;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -74,6 +75,21 @@ abstract class AbstractThriftMojo extends AbstractMojo {
      * @required
      */
     private String thriftExecutable;
+
+    /**
+     *  If set to true, we'll auto-version the executable by tacking on the project's thrift library
+     *  dependency version onto the thriftExecutable name.
+     *
+     *  @parameter default-value=false
+     */
+    private Boolean autoVersionExecutable;
+
+    /**
+     *  For autoversioning, set the separator between the executable name and the version.
+     *
+     *  @parameter default-value="-";
+     */
+    private String autoVersionSeparator;
 
     /**
      * This string is passed to the {@code --gen} option of the {@code thrift} parameter. By default
@@ -163,6 +179,8 @@ abstract class AbstractThriftMojo extends AbstractMojo {
                     // Quick fix to fix issues with two mvn installs in a row (ie no clean)
                     cleanDirectory(outputDirectory);
 
+                    autoVersionExecutableIfNecessary();
+
                     Thrift thrift = new Thrift.Builder(thriftExecutable, outputDirectory)
                             .setGenerator(generator)
                             .addThriftPathElement(thriftSourceRoot)
@@ -190,6 +208,31 @@ abstract class AbstractThriftMojo extends AbstractMojo {
             getLog().info(format("%s does not exist. Review the configuration or consider disabling the plugin.",
                     thriftSourceRoot));
         }
+    }
+
+    private void autoVersionExecutableIfNecessary() {
+        if (!autoVersionExecutable) {
+            return;
+        }
+
+        List<Dependency> deps = project.getDependencies();
+        String version = null;
+        for (Dependency dep : deps) {
+            if (dep.getGroupId().equals("org.apache.thrift")) {
+                if (dep.getArtifactId().equals("thrift") || dep.getArtifactId().equals("libthrift")) {
+                    version = dep.getVersion();
+                    break;
+                }
+            }
+        }
+        if (thriftExecutable.toLowerCase().endsWith(".exe")) {
+            int cutoff = thriftExecutable.length() - 4;
+            String suffix = thriftExecutable.substring(cutoff);
+            thriftExecutable = thriftExecutable.substring(0, cutoff) + autoVersionSeparator + version + suffix;
+        } else {
+            thriftExecutable = thriftExecutable + autoVersionSeparator + version;
+        }
+        getLog().info(format("Auto versioned thrift executable to \"%s\"", thriftExecutable));
     }
 
     ImmutableSet<File> findGeneratedFilesInDirectory(File directory) throws IOException {

--- a/src/main/java/org/apache/thrift/maven/Thrift.java
+++ b/src/main/java/org/apache/thrift/maven/Thrift.java
@@ -97,7 +97,7 @@ final class Thrift {
             command.add("-I");
             command.add(thriftPathElement.toString());
         }
-        command.add("-out");
+        command.add("-o");
         command.add(javaOutputDirectory.toString());
         command.add("--gen");
         command.add(generator);


### PR DESCRIPTION
I have a number of mavenized thrift projects with different versions (from 0.4.0 through 0.6.1 to 0.7.0). In /usr/local/bin, I have thrift-0.4.0, thrift-0.6.1, thrift-0.7.0.

This patch adds an autoVersionExecutable option that will look for the project's thrift dependency, and uses that as a suffix for the executable. 

For broad version support, I had to revert "-out" to "-o" as older thrift executables don't support this. Shouldn't be too much of an issue. 
