### PR TITLE
add maven central sync requirements on pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,33 @@
     <packaging>maven-plugin</packaging>
     <name>Maven Thrift Plugin</name>
     <version>0.1.12-SNAPSHOT</version>
+    <description>Maven Thrift Plugin that executes the thrift code generator</description>
+    <url>https://github.com/dtrott/maven-thrift-plugin</url>
 
     <prerequisites>
         <maven>2.0.6</maven>
     </prerequisites>
 
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <scm>
+        <url>https://github.com/dtrott/maven-thrift-plugin</url>
         <connection>scm:git:git://github.com/dtrott/maven-thrift-plugin.git</connection>
     </scm>
+
+    <developers>
+        <developer>
+            <id>drott</id>
+            <name>David Trott</name>
+            <email>github@davidtrott.com</email>
+        </developer>
+    </developers>
 
     <distributionManagement>
         <downloadUrl>http://maven.davidtrott.com/repository</downloadUrl>


### PR DESCRIPTION
To put this plugin to maven central repository, pom.xml must satisfy some requirements: [Central Sync Requirements](https://docs.sonatype.org/display/Repository/Central+Sync+Requirements)

I like this plugin and I want this plugin to upload on Maven Central Repository!

After this pull request merged...
You can upload this plugin on central repository yourself: [Uploading Your Jar to Maven Central](http://kirang89.github.io/blog/2013/01/20/uploading-your-jar-to-maven-central/)
...or I can done it myself: [Uploading 3rd-party Artifacts to The Central Repository](https://docs.sonatype.org/display/Repository/Uploading+3rd-party+Artifacts+to+The+Central+Repository)
