### PR TITLE
thrift-as-dependency support

### DIFF
--- a/src/main/java/org/apache/thrift/maven/AbstractThriftMojo.java
+++ b/src/main/java/org/apache/thrift/maven/AbstractThriftMojo.java
@@ -79,7 +79,7 @@ abstract class AbstractThriftMojo extends AbstractMojo {
 
     public static final String OS_CLASSIFIER_MAC = "mac";
     public static final String OS_CLASSIFIER_WINDOWS = "win";
-    public static final String OS_CLASSIFIER_LINUX = "lin";
+    public static final String OS_CLASSIFIER_LINUX = "nix";
 
     /**
      * The current Maven project.


### PR DESCRIPTION
Hi!

First of all, thank you for your plugin! I made some major changes in it, but i'm think that you will love it:)

My proposal is to use thrift executable as usual maven dependency, because in our projects there was a problem with it, each project was shipped with binaries in source control, and that's sucks:)

To test it, you should have thrift binaries in your repo. For GAV see new constants in AbstractThriftMojo.java.

Cheers!
