### PR TITLE
Added thrift version detection and enforcement

### DIFF
--- a/src/main/java/org/apache/thrift/maven/AbstractThriftMojo.java
+++ b/src/main/java/org/apache/thrift/maven/AbstractThriftMojo.java
@@ -138,6 +138,16 @@ abstract class AbstractThriftMojo extends AbstractMojo {
     private boolean hashDependentPaths;
 
     /**
+     * Set thrift version that should be enforced for the build.
+     * <p/>
+     * The mojo execution will fail if different thrift version will be found
+     * instead.
+     *
+     * @parameter
+     */
+    private String enforceThriftVersion;
+
+    /**
      * @parameter
      */
     private Set<String> includes = ImmutableSet.of(DEFAULT_INCLUDES);
@@ -189,6 +199,23 @@ abstract class AbstractThriftMojo extends AbstractMojo {
                             .addThriftPathElements(asList(additionalThriftPathElements))
                             .addThriftFiles(thriftFiles)
                             .build();
+
+                    // Detect thrift version (and also print it out which is very useful)
+                    String thriftVersion = thrift.getVersion();
+                    if(thriftVersion == null) {
+                        getLog().error("thrift failed output: " + thrift.getOutput());
+                        getLog().error("thrift failed error: " + thrift.getError());
+                        throw new MojoFailureException("Can't detect thrift version. Verify that the thriftExecutable parameter contains valid value.");
+                    }
+                    getLog().info("Using thrift version: " + thrift.getVersion());
+
+                    // Enforce thrift version if specified
+                    if(enforceThriftVersion != null && !enforceThriftVersion.equals(thriftVersion)) {
+                        throw new MojoFailureException("Thrift version miss match. Requested version "
+                          + enforceThriftVersion + " but version " + thriftVersion
+                          + " has been found instead.");
+                    }
+
                     final int exitStatus = thrift.compile();
                     if (exitStatus != 0) {
                         getLog().error("thrift failed output: " + thrift.getOutput());

--- a/src/main/java/org/apache/thrift/maven/Thrift.java
+++ b/src/main/java/org/apache/thrift/maven/Thrift.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import org.codehaus.plexus.util.cli.CommandLineException;
 import org.codehaus.plexus.util.cli.CommandLineUtils;
 import org.codehaus.plexus.util.cli.Commandline;
+import sun.tools.jar.CommandLine;
 
 import java.io.File;
 import java.util.List;
@@ -99,6 +100,32 @@ final class Thrift {
 
         // result will always be 0 here.
         return 0;
+    }
+
+    /**
+     * Get the version of used thrift command.
+     * <p/>
+     *
+     * @return String representation of the version (0.7.0, 0.9.0, ...)
+     * @throws CommandLineException
+     */
+    public String getVersion() throws CommandLineException {
+        Commandline cl = new Commandline();
+        cl.setExecutable(executable);
+        cl.addArguments(new String[]{ "-version" });
+
+        final int result = CommandLineUtils.executeCommandLine(cl, null, output, error);
+        if(result != 1) {
+            return null;
+        }
+
+        // We're expecting that the output will be single line such as:
+        //   Thrift version 0.9.0
+        String out = output.getOutput();
+
+        // We're assuming that the version will be the final element on the line
+        String []split = out.split(" ");
+        return split[split.length -1].trim();
     }
 
     /**

--- a/src/test/java/org/apache/thrift/maven/TestThrift.java
+++ b/src/test/java/org/apache/thrift/maven/TestThrift.java
@@ -29,6 +29,7 @@ import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -146,6 +147,18 @@ public class TestThrift {
             fail("Expected IllegalStateException");
         } catch (IllegalStateException e) {
         }
+    }
+
+    @Test
+    public void testGetVersion() throws Exception {
+        final File sharedThrift = new File(idlDir, "shared.thrift");
+        builder.addThriftFile(sharedThrift);
+        final Thrift thrift = builder.build();
+        String version = thrift.getVersion();
+
+        // As we are using external library we don't know what exactly to expect
+        assertNotNull(version);
+        assertFalse(version.isEmpty());
     }
 
     @After


### PR DESCRIPTION
We are using this plugin on parquet-format project, where we require certain thrift version. Our build fails with very confusing messages if different thrift version will be used instead. Hence it would be great if the thrift plugin would be able enforce which thrift version should be used.

Current implementation adds ability to only enforce one given version. We can add ability to specify version range in the future (such as 0.9.\* or 0.9.0+).
