### PR TITLE
Transitive inclusion path should not walk the full directory structure

### DIFF
--- a/src/main/java/org/apache/thrift/maven/AbstractThriftMojo.java
+++ b/src/main/java/org/apache/thrift/maven/AbstractThriftMojo.java
@@ -294,13 +294,14 @@ abstract class AbstractThriftMojo extends AbstractMojo {
                 for (JarEntry jarEntry : list(classpathJar.entries())) {
                     final String jarEntryName = jarEntry.getName();
                     if (jarEntry.getName().endsWith(THRIFT_FILE_SUFFIX)) {
+                        final File dependentTreeRoot = new File(temporaryThriftFileDirectory,
+                            truncatePath(classpathJar.getName()));
                         final File uncompressedCopy =
-                                new File(new File(temporaryThriftFileDirectory,
-                                        truncatePath(classpathJar.getName())), jarEntryName);
+                                new File(dependentTreeRoot, jarEntryName);
                         uncompressedCopy.getParentFile().mkdirs();
                         copyStreamToFile(new RawInputStreamFacade(classpathJar
                                 .getInputStream(jarEntry)), uncompressedCopy);
-                        thriftDirectories.add(uncompressedCopy.getParentFile());
+                        thriftDirectories.add(dependentTreeRoot);
                     }
                 }
             } else if (classpathElementFile.isDirectory()) {


### PR DESCRIPTION
Let us that **project A** has the following file:
src/main/thrift/com/example/a.thrift
Assume we have generated a jar using this plugin on project A

Our project (say project B) depends on a.thrift. The way to accomplish
this is by declaring the maven artifact of project A as a dependency in
our project and then referencing the file as follows:

``` thrift
// contents of com/acme/b.thrift
include "com/example/a.thrift"
```

Now, when the plugin is invoked, the expected behaviour is as follows:
- a.thrift gets unpacked into a temp directory as temp/hashcode/com/example/a.thrift
- the thrift executable is called on com/acme/b.thrift with the correct include paths

The curent implementation passes _temp/hashcode/com/example/_ as an
include base directory. The issue with this approach is that the fully
qualified reference that exists in b.thrift does not get resolved. The
correct approach is to set _temp/hashcode/_ as the include directory.
Note that this change has no effect on dependencies where the IDL files
are placed only in the source root i.e. they are not placed inside
sub-directories
